### PR TITLE
Adding Gnome 41 support

### DIFF
--- a/app-grid-tweaks@Selenium-H/metadata.json
+++ b/app-grid-tweaks@Selenium-H/metadata.json
@@ -6,7 +6,8 @@
   "settings-schema": "org.gnome.shell.extensions.app-grid-tweaks",
   "shell-version": [
     "3.38",
-    "40"
+    "40",
+    "41"
   ],
   "status": "",
   "url": "https://github.com/Selenium-H/App-Grid-Tweaks",


### PR DESCRIPTION
This is just the fix made by @heinthanth in #12, but added in a PR. 
The only change is I added 41 in metadata.json since it seems to be the only problem.

Tested and confirmed working on my machine with Manjaro and Gnome 41.1